### PR TITLE
feat: form last update

### DIFF
--- a/pkg/bot/factory.go
+++ b/pkg/bot/factory.go
@@ -49,7 +49,7 @@ func (t *TelegramBot) Updates(ctx context.Context, errChan chan<- error) {
 
 func (t *TelegramBot) AddHandlers(h ...update.Handler) {
 	if t.updateGateway == nil {
-		log.Fatalln("[update gateway] not initialized")
+		t.updateGateway = update.NewGateway(h...)
 		return
 	}
 

--- a/pkg/bot/update/form.go
+++ b/pkg/bot/update/form.go
@@ -34,8 +34,13 @@ type FormFieldPrompt struct {
 	Order  int
 }
 
+type FormAnswerData[T any] struct {
+	Data             *T
+	LastAnswerUpdate tgbotapi.Update
+}
+
 type NewFormHandlerParams[T any] struct {
-	OnSubmit func(ctx context.Context, data *T) error
+	OnSubmit func(ctx context.Context, data *FormAnswerData[T]) error
 	Bot      interface {
 		Send(tgbotapi.Chattable) (tgbotapi.Message, error)
 	}
@@ -144,7 +149,12 @@ func NewFormHandlers[T any](
 
 		if step.Action == "submit" {
 			if params.OnSubmit != nil {
-				if err := params.OnSubmit(ctx, form); err != nil {
+				data := &FormAnswerData[T]{
+					Data:             form,
+					LastAnswerUpdate: update,
+				}
+
+				if err := params.OnSubmit(ctx, data); err != nil {
 					log.Printf("error submitting form answer (%v): %v\n", answer, err)
 					return err
 				}


### PR DESCRIPTION
- Add last Telegram Update to the `OnSubmit` data

If you need the Chat/User information during form submission, there is currently no way to access it.
My solution is to include the last Update in the data that is passed to the `OnSubmit` handler function.

- Fix Gateway initialization in the `AddHandlers` function

The UpdateGateway was only instantiated if the `WithUpdateHandlers` was passed in the `bot.New()` options.
If dont pass it and you need to instantiate your handlers later, there is no way to do so, as calling the `bot.Updates()` function will fail because the update `Gateway` is not instantiated.